### PR TITLE
Ask the user to continue only if settings are correctly displayed

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -16,6 +16,8 @@ echo " * Common Path: $CM_REPO"
 echo " * Custom Installation Remote: $CS_REMOTE"
 echo " * Custom Installation Path: $CS_REPO"
 echo ""
+read -p "Continue ? [Enter]"
+echo ""
 echo ""
 
 if [ ! -f "/Library/Developer/CommandLineTools/usr/bin/clang" ]; then


### PR DESCRIPTION
It would be a simple step to ask the user to continue only if the settings displayed are, indeed, correct. This works nicely with #2, and is also a saviour if the user forgot to provide repo location to his `xc-custom` repo.
